### PR TITLE
add yuris/extYuRis tool

### DIFF
--- a/yuris/extYuRis/YscmDef.go
+++ b/yuris/extYuRis/YscmDef.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"github.com/regomne/eutil/codec"
+	"github.com/regomne/eutil/textFile"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type yscmHeader struct {
+	Meta  YbnHeader
+	Count uint32
+	Unk   uint32 //zero
+}
+type yscmInfo struct {
+	Header        yscmHeader
+	Commands      []yscmCommandInfo
+	ErrorOffset   int64
+	ErrorMessages []string //length: 37?
+	Unk           []byte
+}
+
+type yscmCommandInfo struct {
+	Name    string
+	Actions []yscmCommandActionInfo
+}
+
+type yscmCommandActionInfo struct {
+	Name    string
+	ArgType byte
+	ArgVaid byte
+}
+
+func parseYscm(oriStm []byte, codePage int) (script yscmInfo, err error) {
+	stm := bytes.NewReader(oriStm)
+	binary.Read(stm, binary.LittleEndian, &script.Header)
+	logln("header:", script.Header)
+	header := &script.Header
+	if bytes.Compare(header.Meta.Magic[:], []byte("YSCM")) != 0 {
+		err = fmt.Errorf("not a ybn file")
+		return
+	}
+	script.Commands = make([]yscmCommandInfo, script.Header.Count)
+	for i := 0; i < int(script.Header.Count); i++ {
+		cmd := &script.Commands[i]
+		cmd.Name = readAnsiStr(stm, codePage)
+		var actionCount uint8
+		binary.Read(stm, binary.LittleEndian, &actionCount)
+		cmd.Actions = make([]yscmCommandActionInfo, actionCount)
+		for j := 0; j < int(actionCount); j++ {
+			act := &cmd.Actions[j]
+			act.Name = readAnsiStr(stm, codePage)
+			binary.Read(stm, binary.LittleEndian, &act.ArgType)
+			binary.Read(stm, binary.LittleEndian, &act.ArgVaid)
+		}
+	}
+	pos, err := stm.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return yscmInfo{}, err
+	}
+	script.ErrorOffset = pos
+	script.ErrorMessages = make([]string, 37)
+	for i := 0; i < len(script.ErrorMessages); i++ {
+		script.ErrorMessages[i] = readAnsiStr(stm, codePage)
+	}
+	script.Unk = make([]byte, 256)
+	stm.Read(script.Unk)
+	return
+}
+
+func parseYscmFile(oriStm []byte, outJsonName, outTxtName, outInstructName string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYscm(oriStm, codePage)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	if outJsonName != "" {
+		logln("writing json...")
+		out, err := json.MarshalIndent(script, "", "\t")
+		if err != nil {
+			fmt.Println("error when marshalling json:", err)
+			return false
+		}
+		os.WriteFile(outJsonName, out, os.ModePerm)
+	}
+	if outInstructName != "" {
+		logln("writing instructions...")
+		out := ""
+		for i := range script.Commands {
+			cmd := &script.Commands[i]
+			out += cmd.Name + "("
+			for j := range cmd.Actions {
+				act := &cmd.Actions[j]
+				out += act.Name + "(" + strconv.Itoa(int(act.ArgType)) + "," + strconv.Itoa(int(act.ArgVaid)) + "),"
+			}
+			strings.TrimRight(out, ",")
+			out += ")\n"
+		}
+		strings.TrimRight(out, "\n")
+		os.WriteFile(outInstructName, []byte(out), os.ModePerm)
+	}
+	if outTxtName != "" {
+		logln("extracting text from script...")
+		txt := make([]string, len(script.ErrorMessages))
+		for i, msg := range script.ErrorMessages {
+			txt[i] = msg
+		}
+		logln("encoding text and writing...")
+		out := codec.Encode(strings.Join(txt, "\r\n"), codec.UTF8Sig, codec.Replace)
+		os.WriteFile(outTxtName, out, os.ModePerm)
+	}
+	logln("complete.")
+	return true
+}
+
+func packYscmFile(oriStm []byte, outTxtName, outYbnName string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYscm(oriStm, codePage)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	if outTxtName != "" {
+		logln("loading files...")
+		ls, err := textFile.ReadWin32TxtToLines(outTxtName)
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+		logln("encoding text and writing...")
+		var buffer bytes.Buffer
+		buffer.Write(oriStm[:script.ErrorOffset])
+		for i := range ls {
+			buffer.Write(codec.Encode(ls[i], codePage, codec.Replace))
+			buffer.WriteByte(0)
+		}
+		buffer.Write(script.Unk)
+		os.WriteFile(outYbnName, buffer.Bytes(), os.ModePerm)
+	}
+	logln("complete.")
+	return true
+}

--- a/yuris/extYuRis/YserDef.go
+++ b/yuris/extYuRis/YserDef.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"github.com/regomne/eutil/codec"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type yserHeader struct {
+	Meta  YbnHeader
+	Count uint32
+	Unk   uint32 //zero
+}
+
+type yserInfo struct {
+	Header        yserHeader
+	ErrorMessages []yserErrorMessage
+}
+
+type yserErrorMessage struct {
+	Code    uint32
+	Message string
+}
+
+func parseYserFile(oriStm []byte, outJsonName, outTxtName string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYser(oriStm, codePage)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	if outJsonName != "" {
+		logln("writing json...")
+		out, err := json.MarshalIndent(script, "", "\t")
+		if err != nil {
+			fmt.Println("error when marshalling json:", err)
+			return false
+		}
+		os.WriteFile(outJsonName, out, os.ModePerm)
+	}
+	if outTxtName != "" {
+		logln("writing instructions...")
+		out := ""
+		for i := range script.ErrorMessages {
+			msg := &script.ErrorMessages[i]
+			out += strconv.Itoa(int(msg.Code)) + "->\"" + msg.Message + "\"\n"
+		}
+		strings.TrimRight(out, "\n")
+		os.WriteFile(outTxtName, []byte(out), os.ModePerm)
+	}
+	logln("complete.")
+	return true
+}
+
+func parseYser(oriStm []byte, codePage int) (script yserInfo, err error) {
+	stm := bytes.NewReader(oriStm)
+	binary.Read(stm, binary.LittleEndian, &script.Header)
+	logln("header:", script.Header)
+	header := &script.Header
+	if bytes.Compare(header.Meta.Magic[:], []byte("YSER")) != 0 {
+		err = fmt.Errorf("not a ybn file")
+		return
+	}
+	script.ErrorMessages = make([]yserErrorMessage, script.Header.Count)
+	for i := 0; i < int(script.Header.Count); i++ {
+		msg := &script.ErrorMessages[i]
+		binary.Read(stm, binary.LittleEndian, &msg.Code)
+		msg.Message = readAnsiStr(stm, codePage)
+	}
+	return
+}
+
+func packYserFile(oriStm []byte, outTxtName, outYbnName string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYser(oriStm, codePage)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	if outTxtName != "" {
+		logln("loading files...")
+		txt, err := readFileToString(outTxtName, codePage)
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+		logln("encoding text and writing...")
+		var buffer bytes.Buffer
+		buffer.Write(oriStm[:binary.Size(script.Header)])
+		var writer BufferWriter
+		writer.Buffer = &buffer
+		reg, err := regexp.Compile("(?:^|\\n)([0-9]+)->\"([^\"]+)\"")
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+		matches := reg.FindAllStringSubmatch(txt, -1)
+		for i := range matches {
+			var code, err = strconv.Atoi(matches[i][1])
+			if err != nil {
+				fmt.Println(err)
+				return false
+			}
+			binary.Write(&writer, binary.LittleEndian, uint32(code))
+			buffer.Write(codec.Encode(matches[i][2], codePage, codec.ReplaceHTML))
+			fmt.Println(code, matches[i][2])
+			buffer.WriteByte(0)
+		}
+		os.WriteFile(outYbnName, buffer.Bytes(), os.ModePerm)
+	}
+	logln("complete.")
+	return true
+}

--- a/yuris/extYuRis/YslbDef.go
+++ b/yuris/extYuRis/YslbDef.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"github.com/regomne/eutil/codec"
+	"os"
+	"strings"
+)
+
+type yslbHeader struct {
+	Meta  YbnHeader
+	Count uint32
+	Unk   [256]uint32
+}
+
+type yslbInfo struct {
+	Header yslbHeader
+	Labels []yslbLabel
+}
+
+type yslbLabel struct {
+	Name         string
+	NameHash     uint32
+	CommandIndex uint32
+	ScriptId     uint16
+	Unk1         byte
+	Unk2         byte
+}
+
+func parseYslbFile(oriStm []byte, outJsonName, outInstructName string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYslb(oriStm, codePage)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	if outJsonName != "" {
+		logln("writing json...")
+		out, err := json.MarshalIndent(script, "", "\t")
+		if err != nil {
+			fmt.Println("error when marshalling json:", err)
+			return false
+		}
+		os.WriteFile(outJsonName, out, os.ModePerm)
+	}
+	if outInstructName != "" {
+		logln("writing instructions...")
+		out := ""
+		for i := range script.Labels {
+			label := &script.Labels[i]
+			out += fmt.Sprintf("#=\"%s\" =>yst%05d.ybn.instruct:%5d\n", label.Name, label.ScriptId, label.CommandIndex)
+		}
+		strings.TrimRight(out, "\n")
+		os.WriteFile(outInstructName, []byte(out), os.ModePerm)
+	}
+	logln("complete.")
+	return true
+}
+
+func parseYslb(oriStm []byte, codePage int) (script yslbInfo, err error) {
+	stm := bytes.NewReader(oriStm)
+	binary.Read(stm, binary.LittleEndian, &script.Header)
+	logln("header:", script.Header)
+	header := &script.Header
+	if bytes.Compare(header.Meta.Magic[:], []byte("YSLB")) != 0 {
+		err = fmt.Errorf("not a ybn file")
+		return
+	}
+	script.Labels = make([]yslbLabel, script.Header.Count)
+	for i := 0; i < int(script.Header.Count); i++ {
+		label := &script.Labels[i]
+		var nameLength uint8
+		binary.Read(stm, binary.LittleEndian, &nameLength)
+		encodedName := make([]byte, nameLength)
+		stm.Read(encodedName)
+		label.Name = codec.Decode(encodedName, codePage)
+		binary.Read(stm, binary.LittleEndian, &label.NameHash)
+		binary.Read(stm, binary.LittleEndian, &label.CommandIndex)
+		binary.Read(stm, binary.LittleEndian, &label.ScriptId)
+		binary.Read(stm, binary.LittleEndian, &label.Unk1)
+		binary.Read(stm, binary.LittleEndian, &label.Unk2)
+	}
+	return
+}

--- a/yuris/extYuRis/YstbDef.go
+++ b/yuris/extYuRis/YstbDef.go
@@ -1,0 +1,577 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"github.com/regomne/eutil/codec"
+	"github.com/regomne/eutil/memio"
+	"github.com/regomne/eutil/textFile"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type ystbResourceEntry struct {
+	Type   uint8
+	Res    []byte `json:",omitempty"`
+	ResRaw []byte `json:",omitempty"`
+	ResStr string `json:",omitempty"`
+}
+
+type ystbArgInfo struct {
+	Value uint16
+	Type  uint16
+	Res   ystbResourceEntry
+
+	ResInfo   uint32 `json:",omitempty"`
+	ResOffset uint32 `json:",omitempty"`
+}
+
+type ystbInstInfo struct {
+	Op      uint8
+	LabelId uint16
+	Args    []ystbArgInfo
+}
+
+type ystbInfo struct {
+	Header ystbHeader
+	Insts  []ystbInstInfo
+	Offs   []uint32
+}
+
+type ystbHeader struct {
+	Meta         YbnHeader
+	InstCnt      uint32
+	CodeSize     uint32
+	ArgSize      uint32
+	ResourceSize uint32
+	OffSize      uint32
+	Resv         uint32
+}
+
+type ystbInst struct {
+	Op      uint8
+	ArgCnt  uint8
+	LabelId uint16
+}
+
+type ystbArg struct {
+	Value     uint16
+	Type      uint16
+	ResSize   uint32
+	ResOffset uint32
+}
+
+type ystbResInfo struct {
+	Type uint8
+	Len  uint16
+}
+
+func GetTextFunctionNames() []string {
+	return []string{
+		`"es.sel.set"`,
+		`"es.char.name.mark.set"`,
+		`"es.char.name"`,
+		`"es.input.str.set"`,
+		`"es.tips.def.set"`,
+		`"es.tips.tx.def.set"`,
+	}
+}
+
+func isLongEnglishSentence(s []byte) bool {
+	spaceCount := 0
+	for _, c := range s {
+		if c >= 0x80 {
+			return false
+		} else if c == ' ' {
+			spaceCount++
+		}
+	}
+	if spaceCount > 5 {
+		return true
+	}
+	return false
+}
+
+func isEnglishMsg(arg ystbArgInfo) bool {
+	if arg.Value == 0 && arg.Type == 3 {
+		return isLongEnglishSentence(arg.Res.Res)
+	}
+	return false
+}
+
+func isJapOrChnMsg(arg ystbArgInfo) bool {
+	if arg.Value == 0 && arg.Type == 0 {
+		if len(arg.Res.ResRaw) != 0 && arg.Res.ResRaw[0] > 0x80 {
+			return true
+		}
+	}
+	return false
+}
+
+func guessYstbOp(script *ystbInfo, ops *[256]string) bool {
+	msgStat := [256]int{0}
+	callStat := [256]int{0}
+	for _, inst := range script.Insts {
+		if includes(ops[:], "msg") && includes(ops[:], "call") {
+			if gIsOutputOpcode {
+				fmt.Println("msg\tcall")
+				fmt.Printf("%d\t%d\n", IndexOf(ops[:], "msg"), IndexOf(ops[:], "call"))
+			}
+			return true
+		}
+		if !includes(ops[:], "msg") && len(inst.Args) == 1 && (isJapOrChnMsg(inst.Args[0]) || isEnglishMsg(inst.Args[0])) {
+			msgStat[inst.Op]++
+			if msgStat[inst.Op] > 10 {
+				ops[inst.Op] = "msg"
+			}
+		}
+		if !includes(ops[:], "call") && len(inst.Args) >= 1 &&
+			inst.Args[0].Value == 0 && inst.Args[0].Type == 3 {
+			res := &inst.Args[0].Res
+			s := string(res.Res)
+			if res.Type == 0x4d && len(s) > 4 &&
+				s[0] == '"' && s[1] == 'e' && s[len(s)-1] == '"' {
+				callStat[inst.Op]++
+				if callStat[inst.Op] > 5 {
+					ops[inst.Op] = "call"
+				}
+			}
+		}
+	}
+	return false
+}
+
+func decryptYstb(stm []byte, key []byte, header *ystbHeader) {
+	p := uint32(binary.Size(*header))
+	decryptBlock(stm[p:p+header.CodeSize], key)
+	p += header.CodeSize
+	decryptBlock(stm[p:p+header.ArgSize], key)
+	p += header.ArgSize
+	decryptBlock(stm[p:p+header.ResourceSize], key)
+	p += header.ResourceSize
+	decryptBlock(stm[p:p+header.OffSize], key)
+}
+
+func packLineToYstbResource(arg ystbArgInfo, line string, cp int) []byte {
+	ns := codec.Encode(line, cp, codec.ReplaceHTML)
+	if arg.Type == 3 {
+		var bf bytes.Buffer
+		var resInfo ystbResInfo
+		resInfo.Type = arg.Res.Type
+		resInfo.Len = uint16(len(ns))
+		binary.Write(&bf, binary.LittleEndian, &resInfo)
+		bf.Write(ns)
+		return bf.Bytes()
+	}
+	return ns
+}
+
+func isFunctionToExtract(name []byte) bool {
+	names := GetTextFunctionNames()
+	f := strings.ToLower(string(name))
+	for _, v := range names {
+		if strings.Compare(v, f) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func packTxtToYstb(script *ystbInfo, stm []byte, txt []string, ops *[256]string, codePage int, key []byte) (newStm []byte, err error) {
+	argOffStart := uint32(binary.Size(script.Header)) + script.Header.CodeSize
+	argStm := memio.NewWithBytes(stm[argOffStart : argOffStart+script.Header.ArgSize])
+
+	var resTail bytes.Buffer
+
+	resNewOffset := script.Header.ResourceSize
+	argIdx := 0
+	txtIdx := 0
+	for _, inst := range script.Insts {
+		if ops[inst.Op] == "msg" {
+			ns := packLineToYstbResource(inst.Args[0], txt[txtIdx], codePage)
+			txtIdx++
+			resTail.Write(ns)
+			argStm.Seek(int64(argIdx*12)+4, 0)
+			binary.Write(argStm, binary.LittleEndian, uint32(len(ns)))
+			binary.Write(argStm, binary.LittleEndian, resNewOffset)
+			resNewOffset += uint32(len(ns))
+		} else if ops[inst.Op] == "call" {
+			if isFunctionToExtract(inst.Args[0].Res.Res) {
+				for i, arg := range inst.Args[1:] {
+					if arg.Type == 3 &&
+						bytes.Compare(arg.Res.Res, []byte(`""`)) != 0 &&
+						bytes.Compare(arg.Res.Res, []byte(`''`)) != 0 {
+						ns := packLineToYstbResource(arg, txt[txtIdx], codePage)
+						txtIdx++
+						resTail.Write(ns)
+						argStm.Seek(int64((argIdx+1+i)*12)+4, 0)
+						binary.Write(argStm, binary.LittleEndian, uint32(len(ns)))
+						binary.Write(argStm, binary.LittleEndian, resNewOffset)
+						resNewOffset += uint32(len(ns))
+					}
+				}
+			}
+		}
+		argIdx += len(inst.Args)
+	}
+
+	var newYbn bytes.Buffer
+	newHdr := script.Header
+	newHdr.ResourceSize += uint32(resTail.Len())
+	binary.Write(&newYbn, binary.LittleEndian, &newHdr)
+	codeStart := uint32(binary.Size(newHdr))
+	newYbn.Write(stm[codeStart : codeStart+script.Header.CodeSize])
+	newYbn.Write(argStm.Bytes())
+	resStart := argOffStart + script.Header.ArgSize
+	newYbn.Write(stm[resStart : resStart+script.Header.ResourceSize])
+	newYbn.Write(resTail.Bytes())
+	offStart := resStart + script.Header.ResourceSize
+	newYbn.Write(stm[offStart : offStart+script.Header.OffSize])
+
+	outputStm := newYbn.Bytes()
+	if bytes.Compare(key, []byte("\x00\x00\x00\x00")) != 0 {
+		decryptYstb(outputStm, key, &newHdr)
+	}
+
+	return outputStm, nil
+}
+
+func packYstbFile(oriStm []byte, txtName, outYbnName string, key []byte, ops *[256]string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYstb(oriStm, key, "")
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	logln("guessing opcode if not provided...")
+	if !guessYstbOp(&script, ops) {
+		fmt.Println("Can't guess the opcode")
+		return false
+	}
+	logln("reading text:", txtName)
+	ls, err := textFile.ReadWin32TxtToLines(txtName)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	logf("reading text finished, %d lines\n", len(ls))
+	logln("packing text to ybn...")
+	newStm, err := packTxtToYstb(&script, oriStm, ls, ops, codePage, key)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	logln("writing ybn:", outYbnName)
+	os.WriteFile(outYbnName, newStm, os.ModePerm)
+	logln("complete.")
+	return true
+}
+
+func decodeScriptString(script *ystbInfo, ops *[256]string, codePage int) {
+	for i := range script.Insts {
+		inst := &script.Insts[i]
+		for j := range inst.Args {
+			res := &inst.Args[j].Res
+			if len(res.Res) != 0 && res.Type == 77 {
+				res.ResStr = codec.Decode(res.Res, codePage)
+			} else if ops[inst.Op] == "msg" {
+				res.ResStr = codec.Decode(res.ResRaw, codePage)
+			}
+		}
+	}
+}
+
+func extTxtFromYbn(script *ystbInfo, ops *[256]string, codePage int) (txt []string, err error) {
+	txt = make([]string, 0, len(script.Insts)/3)
+	for _, inst := range script.Insts {
+		if ops[inst.Op] == "msg" {
+			if len(inst.Args) != 1 {
+				err = fmt.Errorf("the message op:0x%x has not only 1 argument", inst.Op)
+				return
+			}
+			rawStr := []byte{}
+			if inst.Args[0].Type == 3 {
+				// for English games, it seems the msg op uses type-3 resource
+				rawStr = inst.Args[0].Res.Res
+			} else {
+				// and for Japanese games, it usually uses raw resource
+				rawStr = inst.Args[0].Res.ResRaw
+			}
+			txt = append(txt, codec.Decode(rawStr, codePage))
+		} else if ops[inst.Op] == "call" {
+			if len(inst.Args) < 1 {
+				err = fmt.Errorf("call op:0x%x argument less than 1", inst.Op)
+				return
+			}
+			if isFunctionToExtract(inst.Args[0].Res.Res) {
+				for _, arg := range inst.Args[1:] {
+					if arg.Type == 3 &&
+						bytes.Compare(arg.Res.Res, []byte(`""`)) != 0 &&
+						bytes.Compare(arg.Res.Res, []byte(`''`)) != 0 {
+						txt = append(txt, codec.Decode(arg.Res.Res, codePage))
+					}
+				}
+			}
+		}
+	}
+	return
+}
+
+func resStr(res ystbResourceEntry, codePage int) string {
+	if len(res.ResStr) != 0 {
+		return res.ResStr
+	} else if len(res.Res) != 0 {
+		return codec.Decode(res.Res, codePage)
+	} else if len(res.ResRaw) != 0 {
+		return codec.Decode(res.ResRaw, codePage)
+	}
+	return ""
+}
+
+func parseYstbFile(oriStm []byte, outJsonName, outTxtName, outDecryptName, outInstructName string, key []byte, ops *[256]string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYstb(oriStm, key, outDecryptName)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	logln("guessing opcode if not provided...")
+	if !guessYstbOp(&script, ops) {
+		fmt.Printf("Guess opcodes failed, msg op:0x%x, call op:0x%x\n", IndexOf(ops[:], "msg"), IndexOf(ops[:], "call"))
+	}
+	if outJsonName != "" {
+		logln("writing json...")
+		if gVerbose {
+			logln("decode some string in json...")
+			decodeScriptString(&script, ops, codePage)
+		}
+		out, err := json.MarshalIndent(script, "", "\t")
+		if err != nil {
+			fmt.Println("error when marshalling json:", err)
+			return false
+		}
+		os.WriteFile(outJsonName, out, os.ModePerm)
+	}
+	if outInstructName != "" {
+		resTypes := map[uint8]string{
+			77: "str",
+		}
+		logln("writing instructions...")
+		out := ""
+		for i := range script.Insts {
+			inst := &script.Insts[i]
+			op := ops[int(inst.Op)]
+			if op == "" { //!op
+				op = strconv.Itoa(int(inst.Op))
+			}
+			switch op {
+			case "msg":
+				out += strings.ReplaceAll(resStr(inst.Args[0].Res, codePage), "\"", "") + "\n"
+				break
+			case "msg-meta":
+				out += "msg-data(" + strconv.Itoa(int(inst.Args[0].Value))
+				if len(inst.Args[0].Res.ResRaw) != 0 {
+					out += ", " + base64.StdEncoding.EncodeToString(inst.Args[0].Res.ResRaw)
+				}
+				out += ")\n"
+				break
+			case "call":
+				out += "\\" + strings.ReplaceAll(resStr(inst.Args[0].Res, codePage), "\"", "")
+				out += "("
+				for i := 1; i < len(inst.Args); i++ {
+					arg := &inst.Args[i]
+					out += strconv.Itoa(int(arg.Value)) + ": " + strconv.Itoa(int(arg.Type)) + " ->"
+					writeType := true
+					resType, ok := resTypes[arg.Res.Type]
+					if !ok {
+						resType = strconv.Itoa(int(arg.Res.Type))
+					}
+					if resType == "str" {
+						writeType = false
+						resS := resStr(arg.Res, codePage)
+						if resS != "''" {
+							out += resS
+						} else {
+							out += "null"
+						}
+					} else {
+						if len(arg.Res.ResRaw) != 0 {
+							out += base64.StdEncoding.EncodeToString(arg.Res.ResRaw)
+						} else if len(arg.Res.Res) != 0 {
+							out += base64.StdEncoding.EncodeToString(arg.Res.Res)
+						} else if arg.ResOffset != 0 && arg.ResInfo != 0 {
+							out += fmt.Sprintf("res::(%v--%v)", arg.ResInfo, arg.ResOffset)
+						} else {
+							out += "~"
+						}
+					}
+					if writeType {
+						out += ":" + resType
+					}
+					if i+1 < len(inst.Args) {
+						out += ", "
+					}
+				}
+				out += ")\n"
+				break
+			default:
+				out += "\\" + op
+				out += "("
+				for i := 0; i < len(inst.Args); i++ {
+					arg := &inst.Args[i]
+					out += strconv.Itoa(int(arg.Value)) + ": " + strconv.Itoa(int(arg.Type)) + " ->"
+					writeType := true
+					resType, ok := resTypes[arg.Res.Type]
+					if !ok {
+						resType = strconv.Itoa(int(arg.Res.Type))
+					}
+					if resType == "str" {
+						writeType = false
+						resS := resStr(arg.Res, codePage)
+						if resS != "''" {
+							out += resS
+						} else {
+							out += "null"
+						}
+					} else {
+						if len(arg.Res.ResRaw) != 0 {
+							out += base64.StdEncoding.EncodeToString(arg.Res.ResRaw)
+						} else if len(arg.Res.Res) != 0 {
+							out += base64.StdEncoding.EncodeToString(arg.Res.Res)
+						} else if arg.ResOffset != 0 && arg.ResInfo != 0 {
+							out += fmt.Sprintf("res::(%v--%v)", arg.ResInfo, arg.ResOffset)
+						} else {
+							out += "~"
+						}
+					}
+					if writeType {
+						out += ":" + resType
+					}
+					if i+1 < len(inst.Args) {
+						out += ", "
+					}
+				}
+				out += ")\n"
+			}
+		}
+		os.WriteFile(outInstructName, []byte(out), os.ModePerm)
+	}
+	if outTxtName != "" {
+		logln("extracting text from script...")
+		txt, err := extTxtFromYbn(&script, ops, codePage)
+		if err != nil {
+			fmt.Println("error when extracting txt:", err)
+			return false
+		}
+		if len(txt) > 0 {
+			logln("encoding text and writing...")
+			out := codec.Encode(strings.Join(txt, "\r\n"), codec.UTF8Sig, codec.Replace)
+			os.WriteFile(outTxtName, out, os.ModePerm)
+		} else {
+			logln("no extracted text...")
+		}
+	}
+	logln("complete.")
+	return true
+}
+
+func parseYstb(oriStm []byte, key []byte, decryptName string) (script ystbInfo, err error) {
+	stm := bytes.NewReader(oriStm)
+	binary.Read(stm, binary.LittleEndian, &script.Header)
+	logln("header:", script.Header)
+	header := &script.Header
+	if bytes.Compare(header.Meta.Magic[:], []byte("YSTB")) != 0 || header.CodeSize != header.InstCnt*4 {
+		err = fmt.Errorf("not a ybn file or file format error")
+		return
+	}
+	fileSize, _ := stm.Seek(0, io.SeekEnd)
+	if uint32(binary.Size(header))+header.CodeSize+header.ArgSize+header.ResourceSize+header.OffSize != uint32(fileSize) {
+		err = fmt.Errorf("file size error")
+		return
+	}
+	if header.Resv != 0 {
+		fmt.Println("reserved is not 0, maybe can't extract all the info")
+	}
+	var decryptedStm io.ReadSeeker
+	if bytes.Compare(key, []byte("\x00\x00\x00\x00")) != 0 {
+		logf("decrypting, key is:%02x %02x %02x %02x\n", key[0], key[1], key[2], key[3])
+		decryptYstb(oriStm, key, header)
+		decryptedStm = bytes.NewReader(oriStm)
+	} else {
+		decryptedStm = bytes.NewReader(oriStm)
+	}
+	if decryptName != "" {
+		logln("write decrypted file...")
+		err1 := os.WriteFile(decryptName, oriStm, 0644)
+		fmt.Println(err1)
+	}
+
+	logln("reading sections...")
+	decryptedStm.Seek(int64(binary.Size(header)), io.SeekStart)
+	script.Insts = make([]ystbInstInfo, header.InstCnt)
+	rawInsts := make([]ystbInst, header.InstCnt)
+	binary.Read(decryptedStm, binary.LittleEndian, &rawInsts)
+	var tArg ystbArg
+	rargs := make([]ystbArg, header.ArgSize/uint32(binary.Size(tArg)))
+	binary.Read(decryptedStm, binary.LittleEndian, &rargs)
+	resStartOff, _ := decryptedStm.Seek(0, io.SeekCurrent)
+	rargIdx := 0
+	logln("parsing instructions...")
+	for i, rinst := range rawInsts {
+		inst := &script.Insts[i]
+		inst.Op = rinst.Op
+		inst.LabelId = rinst.LabelId
+		inst.Args = make([]ystbArgInfo, rinst.ArgCnt)
+		for j := 0; j < int(rinst.ArgCnt); j++ {
+			rarg := &rargs[rargIdx]
+			rargIdx++
+			if rargIdx > len(rargs) {
+				err = fmt.Errorf("count of arguments exceed limit")
+				return
+			}
+			inst.Args[j].Type = rarg.Type
+			inst.Args[j].Value = rarg.Value
+			if rarg.Type == 0 && rinst.ArgCnt != 1 {
+				inst.Args[j].ResInfo = rarg.ResSize
+				inst.Args[j].ResOffset = rarg.ResOffset
+			} else {
+				decryptedStm.Seek(resStartOff+int64(rarg.ResOffset), io.SeekStart)
+				res := &inst.Args[j].Res
+				if rarg.Type == 3 {
+					var resInfo ystbResInfo
+					binary.Read(decryptedStm, binary.LittleEndian, &resInfo)
+					res.Type = resInfo.Type
+					res.Res = make([]byte, resInfo.Len)
+					decryptedStm.Read(res.Res)
+				} else {
+					if rarg.ResSize > 3 {
+						var resInfo ystbResInfo
+						binary.Read(decryptedStm, binary.LittleEndian, &resInfo)
+						if uint32(resInfo.Len)+3 == rarg.ResSize {
+							res.Type = resInfo.Type
+							res.Res = make([]byte, resInfo.Len)
+							decryptedStm.Read(res.Res)
+						} else {
+							decryptedStm.Seek(-3, io.SeekCurrent)
+							res.ResRaw = make([]byte, rarg.ResSize)
+							decryptedStm.Read(res.ResRaw)
+						}
+					} else {
+						res.ResRaw = make([]byte, rarg.ResSize)
+						decryptedStm.Read(res.ResRaw)
+					}
+				}
+			}
+		}
+	}
+	offTblOffset := uint32(binary.Size(header)) + header.CodeSize + header.ArgSize + header.ResourceSize
+	decryptedStm.Seek(int64(offTblOffset), 0)
+	script.Offs = make([]uint32, header.InstCnt)
+	binary.Read(decryptedStm, binary.LittleEndian, &script.Offs)
+	return
+}

--- a/yuris/extYuRis/YstdDef.go
+++ b/yuris/extYuRis/YstdDef.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type ystdHeader struct {
+	Meta  YbnHeader
+	Count uint32
+	Unk   uint32
+}
+
+type ystdInfo struct {
+	Header ystdHeader
+}
+
+func parseYstdFile(oriStm []byte, outJsonName, outInstructName string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYstd(oriStm, codePage)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	if outJsonName != "" {
+		logln("writing json...")
+		out, err := json.MarshalIndent(script, "", "\t")
+		if err != nil {
+			fmt.Println("error when marshalling json:", err)
+			return false
+		}
+		os.WriteFile(outJsonName, out, os.ModePerm)
+	}
+	if outInstructName != "" {
+		logln("writing instructions...")
+		out := fmt.Sprintf("YSTD v%v\n%v\n%v", script.Header.Meta.Version, script.Header.Count, script.Header.Unk)
+		os.WriteFile(outInstructName, []byte(out), os.ModePerm)
+	}
+	logln("complete.")
+	return true
+}
+
+func parseYstd(oriStm []byte, codePage int) (script ystdInfo, err error) {
+	stm := bytes.NewReader(oriStm)
+	binary.Read(stm, binary.LittleEndian, &script.Header)
+	logln("header:", script.Header)
+	header := &script.Header
+	if bytes.Compare(header.Meta.Magic[:], []byte("YSTD")) != 0 {
+		err = fmt.Errorf("not a ybn file")
+		return
+	}
+	return
+}

--- a/yuris/extYuRis/YstlDef.go
+++ b/yuris/extYuRis/YstlDef.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"github.com/regomne/eutil/codec"
+	"os"
+	"strings"
+)
+
+type ystlHeader struct {
+	Meta  YbnHeader
+	Count uint32
+}
+
+type ystlInfo struct {
+	Header  ystlHeader
+	Scripts []ystlScriptInfo
+}
+
+type ystlScriptInfo struct {
+	Id           uint32
+	SourceLength uint32
+	Source       string
+	Unk1         uint32
+	Unk2         uint32
+	Unk3         uint32
+	Unk4         uint32
+	Unk5         uint32
+}
+
+func parseYstlFile(oriStm []byte, outJsonName, outInstructName string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYstl(oriStm, codePage)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	if outJsonName != "" {
+		logln("writing json...")
+		out, err := json.MarshalIndent(script, "", "\t")
+		if err != nil {
+			fmt.Println("error when marshalling json:", err)
+			return false
+		}
+		os.WriteFile(outJsonName, out, os.ModePerm)
+	}
+	if outInstructName != "" {
+		logln("writing instructions...")
+		out := ""
+		for i := range script.Scripts {
+			scr := &script.Scripts[i]
+			out += fmt.Sprintf("yst%05d.ybn => %s  (%v,%v,%v,%v,%v)\n", scr.Id, scr.Source, scr.Unk1, scr.Unk2, scr.Unk3, scr.Unk4, scr.Unk5)
+		}
+		strings.TrimRight(out, "\n")
+		os.WriteFile(outInstructName, []byte(out), os.ModePerm)
+	}
+	logln("complete.")
+	return true
+}
+
+func parseYstl(oriStm []byte, codePage int) (script ystlInfo, err error) {
+	stm := bytes.NewReader(oriStm)
+	binary.Read(stm, binary.LittleEndian, &script.Header)
+	logln("header:", script.Header)
+	header := &script.Header
+	if bytes.Compare(header.Meta.Magic[:], []byte("YSTL")) != 0 {
+		err = fmt.Errorf("not a ybn file")
+		return
+	}
+	script.Scripts = make([]ystlScriptInfo, script.Header.Count)
+	for i := 0; i < int(script.Header.Count); i++ {
+		scr := &script.Scripts[i]
+		binary.Read(stm, binary.LittleEndian, &scr.Id)
+		var sourceLength uint32
+		binary.Read(stm, binary.LittleEndian, &sourceLength)
+		encodedName := make([]byte, sourceLength)
+		stm.Read(encodedName)
+		scr.Source = codec.Decode(encodedName, codePage)
+		binary.Read(stm, binary.LittleEndian, &scr.Unk1)
+		binary.Read(stm, binary.LittleEndian, &scr.Unk2)
+		binary.Read(stm, binary.LittleEndian, &scr.Unk3)
+		binary.Read(stm, binary.LittleEndian, &scr.Unk4)
+		binary.Read(stm, binary.LittleEndian, &scr.Unk5)
+	}
+	return
+}

--- a/yuris/extYuRis/YsvrDef.go
+++ b/yuris/extYuRis/YsvrDef.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"github.com/regomne/eutil/codec"
+	"os"
+)
+
+type ysvrHeader struct {
+	Meta  YbnHeader
+	Count uint16
+}
+
+type ysvrInfo struct {
+	Header ysvrHeader
+	Data   []ysvrDataType
+}
+
+type ysvrDataTypeHeader struct {
+	DataType1 uint8
+	Field0    uint8
+	ScriptId  uint16
+	StoreId   uint16
+	DataType2 uint8
+	Count     uint8
+}
+
+type ysvrDataType struct {
+	Header ysvrDataTypeHeader
+	Unk    []uint32
+	Data   any
+}
+
+func parseYsvrFile(oriStm []byte, outJsonName string, codePage int) bool {
+	logln("parsing ybn...")
+	script, err := parseYsvr(oriStm, codePage)
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return false
+	}
+	if outJsonName != "" {
+		logln("writing json...")
+		out, err := json.MarshalIndent(script, "", "\t")
+		if err != nil {
+			fmt.Println("error when marshalling json:", err)
+			return false
+		}
+		os.WriteFile(outJsonName, out, os.ModePerm)
+	}
+	logln("complete.")
+	return true
+}
+
+func parseYsvr(oriStm []byte, codePage int) (script ysvrInfo, err error) {
+	stm := bytes.NewReader(oriStm)
+	binary.Read(stm, binary.LittleEndian, &script.Header)
+	logln("header:", script.Header)
+	header := &script.Header
+	if bytes.Compare(header.Meta.Magic[:], []byte("YSVR")) != 0 {
+		err = fmt.Errorf("not a ybn file")
+		return
+	}
+	script.Data = make([]ysvrDataType, script.Header.Count)
+	for i := 0; i < int(script.Header.Count); i++ {
+		datatype := &script.Data[i]
+		binary.Read(stm, binary.LittleEndian, &datatype.Header)
+		datatype.Unk = make([]uint32, datatype.Header.Count)
+		binary.Read(stm, binary.LittleEndian, &datatype.Unk)
+		switch datatype.Header.DataType2 {
+		case 0:
+			break
+		case 1:
+			var i int64
+			binary.Read(stm, binary.LittleEndian, &i)
+			datatype.Data = i
+			break
+		case 2:
+			var i float64
+			binary.Read(stm, binary.LittleEndian, &i)
+			datatype.Data = i
+			break
+		case 3:
+			var i uint16
+			binary.Read(stm, binary.LittleEndian, &i)
+			b := make([]byte, i)
+			stm.Read(b)
+			datatype.Data = codec.Decode(b[:], codePage)
+			break
+		}
+	}
+	return
+}

--- a/yuris/extYuRis/extYuRis.go
+++ b/yuris/extYuRis/extYuRis.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"github.com/regomne/eutil/codec"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var gIsOutputOpcode bool
+var gVerbose bool
+
+func logf(fmts string, args ...interface{}) {
+	if gVerbose {
+		fmt.Printf(fmts, args...)
+	}
+}
+
+func logln(args ...interface{}) {
+	if gVerbose {
+		fmt.Println(args...)
+	}
+}
+
+func IndexOf(a []string, s string) int {
+	for k, i := range a {
+		if i == s {
+			return k
+		}
+	}
+	return 0
+}
+
+func includes(a []string, v string) bool {
+	for _, i := range a {
+		if i == v {
+			return true
+		}
+	}
+	return false
+}
+
+func decryptBlock(stm []byte, key []byte) {
+	if len(key) != 4 {
+		panic("key length error")
+	}
+	for i := 0; i < len(stm); i++ {
+		stm[i] ^= key[i&3]
+	}
+	b := stm[0]
+	stm[0] = b
+}
+
+func printUsage(exeName string) {
+	fmt.Println("YBN extractor v3.0")
+	fmt.Printf("Usage: %s -e -input <ybn> [-json <json>] [-txt <txt>] [options]\n", exeName)
+	fmt.Printf("Usage: %s -p -input <ybn> -txt <txt> -new-ybn <new_ybn> [options]\n", exeName)
+	flag.Usage()
+
+	fmt.Printf(`
+About the extraction to different formats:
+  Repacking is only possible from a txt file generated from a ystXXXXX.ybn,
+  ysc.ybn or yse.ybn file.
+  Some ybn variants may only support specific file formats:
+      YSCM:	json,	instruct,	txt
+      YSER:	json,			txt
+      YSLB:	json,	instruct,	txt
+      YSTB:	json,	instruct,	txt,	decrypt
+      YSTD:	json,	instruct
+      YSTL:	json,	instruct
+      YSVR:	json
+
+  Different formats may contain different data depending on the variant.
+  Which formats are supported is decided based on usefulness. In
+  General one can say that (1) json files should contain as much as
+  possible (if possible 1:1 binary reconstruction), (2) instruct files
+  should aim to imitate source code files, (3) txt files should be used for
+  translation purposes and therefore only contain strings and (4) decrypt
+  files should be exactly only the original files without encryption.
+  
+
+About the key:
+  Since the used XOR cipher is easy to break once you have some content like a
+  string. Most games use the default key, but if not, you may try:
+  0x6cfddadb or 0x30731B78. The Program may CRASH or PANIC if not given the
+  correct key. If nothing works, try https://wiremask.eu/tools/xor-cracker/
+
+About the opcode:
+  This program can guess the opcode-msg and opcode-call which is needed, but
+  you need to give it a .ybn which has some msg texts to do it. Generally, you
+  can give it yst0XXXX.ybn where the XXXX is the maximum number among all the
+  ybn file names.
+  You can use:
+
+  %s -e -input yst0XXXX.ybn -output-opcode
+
+  to output the opcodes, and then use them in all the .ybn files of this game.
+  You can also use the -op-other to use other ops to extract or pack text.
+`, exeName)
+}
+
+func parseCmdOps(cds string) (err error, ops [256]string) {
+	cdes := strings.Split(cds, ",")
+	for i := 0; i < len(cdes); i++ {
+		spl := strings.Split(cdes[i], ":")
+		if len(spl) != 2 {
+			err = fmt.Errorf("malformatted Op-Codes")
+			return
+		}
+		opcode, e := strconv.Atoi(spl[0])
+		if e != nil {
+			return e, ops
+		}
+		if opcode > 255 {
+			err = fmt.Errorf("malformatted Op-Codes")
+			return
+		}
+		ops[uint8(opcode)] = spl[1]
+	}
+	return
+}
+
+func parseCp(s string) int {
+	switch s {
+	case "936":
+		return codec.C936
+	case "932":
+		return codec.C932
+	default:
+		return codec.Unknown
+	}
+}
+
+func extractYbnFile(ybnName, outJsonName, outTxtName, outInstructName, outDecryptName string, key []byte, ops *[256]string, codePage int) bool {
+	logln("reading file:", ybnName)
+	oriStm, err := os.ReadFile(ybnName)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	stm := bytes.NewReader(oriStm)
+	magic := make([]byte, 4)
+	binary.Read(stm, binary.LittleEndian, &magic)
+	switch strings.ToUpper(string(magic[:])) {
+	case "YSTB":
+		return parseYstbFile(oriStm, outJsonName, outTxtName, outDecryptName, outInstructName, key, ops, codePage)
+	case "YSLB":
+		return parseYslbFile(oriStm, outJsonName, outInstructName, codePage)
+	case "YSCM":
+		return parseYscmFile(oriStm, outJsonName, outTxtName, outInstructName, codePage)
+	case "YSER":
+		return parseYserFile(oriStm, outJsonName, outTxtName, codePage)
+	case "YSTD":
+		return parseYstdFile(oriStm, outJsonName, outInstructName, codePage)
+	case "YSTL":
+		return parseYstlFile(oriStm, outJsonName, outInstructName, codePage)
+	case "YSVR":
+		return parseYsvrFile(oriStm, outJsonName, codePage)
+	default:
+		fmt.Println("Unknown MAGIC-bytes")
+		return false
+	}
+}
+
+func packYbnFile(ybnName, outTxtName, outYbnName string, key []byte, ops *[256]string, codePage int) bool {
+	logln("reading file:", ybnName)
+	oriStm, err := os.ReadFile(ybnName)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	stm := bytes.NewReader(oriStm)
+	magic := make([]byte, 4)
+	binary.Read(stm, binary.LittleEndian, &magic)
+	switch strings.ToUpper(string(magic[:])) {
+	case "YSTB":
+		return packYstbFile(oriStm, outTxtName, outYbnName, key, ops, codePage)
+	case "YSCM":
+		return packYscmFile(oriStm, outTxtName, outYbnName, codePage)
+	case "YSER":
+		return packYserFile(oriStm, outTxtName, outYbnName, codePage)
+	default:
+		fmt.Println("Unknown MAGIC-bytes or packing not supported")
+		return false
+	}
+}
+
+func main() {
+	retCode := 0
+	defer os.Exit(retCode)
+	isExtract := flag.Bool("e", false, "extract a file")
+	isPack := flag.Bool("p", false, "pack a ybn")
+	inInputBinaryName := flag.String("input", "", "input ybn file name")
+	outJsonName := flag.String("json", "", "output json file name")
+	outInstructName := flag.String("instruct", "", "output instruct file name")
+	outTxtName := flag.String("txt", "", "output txt file name")
+	outDecryptName := flag.String("decrypt", "", "output decrypted file name")
+	outYbnName := flag.String("new-ybn", "", "output ybn file name")
+	keyInt := flag.Int64("key", 0x96ac6fd3, "decode key")
+	codePage := flag.String("cp", "932", "specify code page")
+	outputOpCode := flag.Bool("output-opcode", false, "output the opcode guessed")
+	inOpCodes := flag.String("ops", "", "specify op-code names like 90:msg,29:call")
+	verbose := flag.Bool("v", false, "verbose output")
+	flag.Parse()
+	key := [4]byte{}
+	key[0] = byte(*keyInt & 0xff)
+	key[1] = byte((*keyInt >> 8) & 0xff)
+	key[2] = byte((*keyInt >> 16) & 0xff)
+	key[3] = byte((*keyInt >> 24) & 0xff)
+	var opCodes [256]string
+	if *inOpCodes != "" {
+		var err error
+		err, opCodes = parseCmdOps(*inOpCodes)
+		if err != nil {
+			printUsage(os.Args[0])
+			return
+		}
+	}
+	gIsOutputOpcode = *outputOpCode
+	gVerbose = *verbose
+	if (*isExtract && *isPack) || (!*isExtract && !*isPack) ||
+		((*isPack || *isExtract) && *inInputBinaryName == "") ||
+		(*isPack && (*outYbnName == "" || *outTxtName == "")) {
+		printUsage(os.Args[0])
+		return
+	}
+	if *isExtract {
+		extractYbnFile(*inInputBinaryName, *outJsonName, *outTxtName, *outInstructName, *outDecryptName, key[:], &opCodes, parseCp(*codePage))
+	} else if *isPack {
+		packYbnFile(*inInputBinaryName, *outTxtName, *outYbnName, key[:], &opCodes, parseCp(*codePage))
+	} else {
+		printUsage(os.Args[0])
+		return
+	}
+}

--- a/yuris/extYuRis/go.mod
+++ b/yuris/extYuRis/go.mod
@@ -1,0 +1,11 @@
+module extYuRis
+
+go 1.20
+
+require (
+	github.com/regomne/eutil/codec v0.0.0-20210629022305-0392e03e7f5c
+	github.com/regomne/eutil/memio v0.0.0-20210629022305-0392e03e7f5c
+	github.com/regomne/eutil/textFile v0.0.0-20210629022305-0392e03e7f5c
+)
+
+require golang.org/x/text v0.9.0 // indirect

--- a/yuris/extYuRis/ybnDef.go
+++ b/yuris/extYuRis/ybnDef.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"github.com/regomne/eutil/codec"
+	"io"
+	"os"
+	"strings"
+)
+
+type YbnHeader struct {
+	Magic   [4]byte
+	Version uint32
+}
+
+func readFileToString(fileName string, codePage int) (s string, err error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	stats, statsErr := file.Stat()
+	if statsErr != nil {
+		err = statsErr
+		return
+	}
+
+	var size = stats.Size()
+	fileBytes := make([]byte, size)
+	bufr := bufio.NewReader(file)
+	_, readErr := bufr.Read(fileBytes)
+	if readErr != nil {
+		err = readErr
+		return
+	}
+	s = codec.Decode(fileBytes, codePage)
+	return
+}
+
+func readFileToLines(fileName string, codePage int) (s []string, err error) {
+	txt, readErr := readFileToString(fileName, codePage)
+	if readErr != nil {
+		return nil, readErr
+	}
+	s = strings.Split(txt, "\n")
+	for i := range s {
+		s[i] = strings.Trim(s[i], "\r\n")
+	}
+	return
+}
+
+func readAnsiStr(r io.Reader, codePage int) string {
+	var bf bytes.Buffer
+	var b byte
+	binary.Read(r, binary.LittleEndian, &b)
+	for b != 0 {
+		bf.WriteByte(b)
+		binary.Read(r, binary.LittleEndian, &b)
+	}
+	buffer := bf.Bytes()
+	if len(buffer) == 0 {
+		return ""
+	}
+	return codec.Decode(buffer, codePage)
+}
+
+type BufferWriter struct {
+	Buffer *bytes.Buffer
+}
+
+func (buff *BufferWriter) Write(b []byte) (n int, err error) {
+	n, err = buff.Buffer.Write(b)
+	return
+}


### PR DESCRIPTION
Since extYbn only supports YSTB files and only exports the strings only ore json, which in my opinion is not very readable, I wrote this tool, which
(1) supports all ybn files except yscfg.ybn with extraction of basically all contained data (even if I couldn't make sense of some of it, please tell me if you can) and repacking of strings whereever possible
(2) supports exporting into instruction files which are meant to be similar in some aspects to Yu-Ris-Engine's source files
(3) dropped support for text extraction from custom Op-Codes, since it makes repacking of exported txt files unreliable
(4) added support for quick addition of more Op-Codes for text extraction
(5) implemented the in extYbn implemented but out-commented export of raw, but decrypted YSTB files

In this whole process I tried, but I wasn't able to get any kind of SDK with working instructions how to use it. If somebody can help me compile my own scripts, it would help me very much in improving this tool so I can automatically decompile Op-Codes except for msg and call (and msg-metadata?).